### PR TITLE
Fix chat opening for group conversations

### DIFF
--- a/func/funcoes.js
+++ b/func/funcoes.js
@@ -690,6 +690,18 @@ async function alterarFuncaoGrupo(groupId, funcIdentifier, value) {
     }
 }
 
+async function abrirConversa(chatId) {
+    try {
+        if (client.interface && typeof client.interface.openChatWindow === 'function') {
+            await client.interface.openChatWindow(chatId);
+        } else {
+            await client.getChatById(chatId);
+        }
+    } catch (error) {
+        console.error(`Erro ao abrir conversa do grupo ${chatId}:`, error);
+    }
+}
+
 
 
 
@@ -709,4 +721,5 @@ module.exports = {
     alterarFuncaoGrupo,
     alterarBemVindo,
     obterConfiguracaoGrupo,
+    abrirConversa,
 };

--- a/func/sorteio.js
+++ b/func/sorteio.js
@@ -2,6 +2,7 @@ const client = require('../client.js');
 const fs = require('fs');
 const path = require('path');
 const moment = require('moment-timezone');
+const { abrirConversa } = require('./funcoes.js');
 
 // Defina o caminho para o arquivo JSON onde os sorteios serão armazenados
 const sorteiosPath = path.join(__dirname, '../db/sorteio/sorteio.json');
@@ -214,7 +215,7 @@ async function iniciarVerificacaoSorteiosAtivos() {
         const participantes = sorteio.participantes;
 
         // Abre a janela do chat do grupo ao encontrar um sorteio ativo
-        await client.interface.openChatWindow(sorteio.idGrupo);
+        await abrirConversa(sorteio.idGrupo);
 
         if (vencedores && vencedores.length > 0) {
           // Exibe os vencedores no console antes de mencioná-los

--- a/index.js
+++ b/index.js
@@ -56,7 +56,8 @@ const {
   alterarBemVindo,
   checkIfAdmin,
   upload,
-  verificarAluguelAtivo
+  verificarAluguelAtivo,
+  abrirConversa
 } = require('./func/funcoes.js');
 const {
   criarMetadadoGrupo,
@@ -1581,7 +1582,7 @@ client.on('message', async (message) => {
 
         sorteio.idMensagem = pollMessage.id._serialized;
         criarSorteio(from, tituloSorteio, duracaoSorteio, numGanhadores, limiteParticipantes, pollMessage.id._serialized);
-        client.interface.openChatWindow(from);
+        await abrirConversa(from);
 
         setTimeout(async () => {
           const sorteioAtual = carregarSorteios().find(s => s.idMensagem === pollMessage.id._serialized);


### PR DESCRIPTION
## Summary
- add `abrirConversa` helper to open group chats safely
- use `abrirConversa` in raffle flow
- update imports to include new helper

## Testing
- `node --check index.js`
- `node --check func/funcoes.js`
- `node --check func/sorteio.js`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68893bfdd37483238df3b2d3aed1490f